### PR TITLE
Refactor/32 before logging merge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,4 +99,3 @@ websockets==15.0.1
 wrapt==1.17.2
 yarg==0.1.10
 zipp==3.21.0
-google-cloud-logging==3.12.1

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,8 @@ TXTGEN_MODEL_ID = os.getenv("TXTGEN_MODEL_ID")
 EMBEDDING_MODEL_ID = os.getenv("EMBED_MODEL_ID")
 JSON_FILENAME = os.getenv("CREDENTIAL_PATH")
 CREDENTIAL_PATH = os.path.join(PROJECT_ROOT, JSON_FILENAME) #json needs to be on the same directory as the .env file
+WEBHOOK_URL = os.getenv("WEBHOOK_URL")
+
 
 if not PERSPECTIVE_API_KEY:
     raise ValueError("PERSPECTIVE_API_KEY가 .env에 설정되어 있지 않습니다.")

--- a/src/core/ai_logger.py
+++ b/src/core/ai_logger.py
@@ -1,9 +1,9 @@
 import logging
 import requests
-from google.cloud import logging as gcp_logging
-from google.cloud.logging_v2.handlers import CloudLoggingHandler
-from google.oauth2 import service_account
-from src.config import CREDENTIAL_PATH, WEBHOOK_URL
+# from google.cloud import logging as gcp_logging
+# from google.cloud.logging_v2.handlers import CloudLoggingHandler
+# from google.oauth2 import service_account
+from src.config import WEBHOOK_URL
 
 DISCORD_WEBHOOK_URL = WEBHOOK_URL  # 여기에 본인 Webhook 넣기
 
@@ -16,32 +16,36 @@ def send_to_discord(message: str):
 class DiscordHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         try:
-            msg = self.format(record)
             if record.levelno >= logging.WARNING:
+                msg = self.format(record)
                 send_to_discord(f"[AI LOG] {msg}")
         except Exception:
-            pass  # 실패해도 앱 동작엔 영향 없음
+            pass
 
 def get_ai_logger() -> logging.Logger:
     logger = logging.getLogger("ai")
 
     if not logger.handlers:
-        # 1. GCP 로깅 핸들러
-        credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_PATH)
-        client = gcp_logging.Client(credentials=credentials)
-        cloud_handler = CloudLoggingHandler(client)
-        cloud_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
-        logger.addHandler(cloud_handler)
-
-        # 2. 콘솔 출력
+        # ✅ 콘솔 핸들러
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
         logger.addHandler(stream_handler)
 
-        # 3. Discord 핸들러 추가
+        # ✅ Discord 핸들러
         discord_handler = DiscordHandler()
         discord_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
         logger.addHandler(discord_handler)
+
+        # ✅ Cloud Logging (보존됨)
+        # try:
+        #     credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_PATH)
+        #     client = gcp_logging.Client(credentials=credentials)
+        #     cloud_handler = CloudLoggingHandler(client)
+        #     cloud_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
+        #     logger.addHandler(cloud_handler)
+        #     print("[AI 로거] GCP Cloud Logging 연동 완료")
+        # except Exception as e:
+        #     print("[AI 로거] GCP Cloud Logging 연동 실패:", e)
 
         logger.setLevel(logging.INFO)
         logger.propagate = False

--- a/src/core/ai_logger.py
+++ b/src/core/ai_logger.py
@@ -1,0 +1,33 @@
+# src/core/logger_ai.py
+import logging
+from google.cloud import logging as gcp_logging
+from google.cloud.logging_v2.handlers import CloudLoggingHandler
+from google.oauth2 import service_account
+from src.config import CREDENTIAL_PATH
+
+def get_ai_logger() -> logging.Logger:
+    logger = logging.getLogger("ai")
+
+    if not logger.handlers:
+        try:
+            # ✅ vertex_client와 동일한 인증 방식 사용
+            credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_PATH)
+            client = gcp_logging.Client(credentials=credentials)
+
+            cloud_handler = CloudLoggingHandler(client)
+            cloud_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
+            logger.addHandler(cloud_handler)
+
+            print("[AI 로거] GCP Cloud Logging 연동 완료")
+        except Exception as e:
+            print("[AI 로거] GCP 연동 실패 - 콘솔로만 출력됩니다:", e)
+
+        # ✅ 콘솔 핸들러는 항상 추가
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
+        logger.addHandler(stream_handler)
+
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+
+    return logger

--- a/src/core/ai_logger.py
+++ b/src/core/ai_logger.py
@@ -1,31 +1,47 @@
-# src/core/logger_ai.py
 import logging
+import requests
 from google.cloud import logging as gcp_logging
 from google.cloud.logging_v2.handlers import CloudLoggingHandler
 from google.oauth2 import service_account
-from src.config import CREDENTIAL_PATH
+from src.config import CREDENTIAL_PATH, WEBHOOK_URL
+
+DISCORD_WEBHOOK_URL = WEBHOOK_URL  # 여기에 본인 Webhook 넣기
+
+def send_to_discord(message: str):
+    try:
+        requests.post(DISCORD_WEBHOOK_URL, json={"content": message})
+    except Exception as e:
+        print(f"[AI 로거] Discord 전송 실패: {e}")
+
+class DiscordHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+            if record.levelno >= logging.WARNING:
+                send_to_discord(f"[AI LOG] {msg}")
+        except Exception:
+            pass  # 실패해도 앱 동작엔 영향 없음
 
 def get_ai_logger() -> logging.Logger:
     logger = logging.getLogger("ai")
 
     if not logger.handlers:
-        try:
-            # ✅ vertex_client와 동일한 인증 방식 사용
-            credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_PATH)
-            client = gcp_logging.Client(credentials=credentials)
+        # 1. GCP 로깅 핸들러
+        credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_PATH)
+        client = gcp_logging.Client(credentials=credentials)
+        cloud_handler = CloudLoggingHandler(client)
+        cloud_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
+        logger.addHandler(cloud_handler)
 
-            cloud_handler = CloudLoggingHandler(client)
-            cloud_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
-            logger.addHandler(cloud_handler)
-
-            print("[AI 로거] GCP Cloud Logging 연동 완료")
-        except Exception as e:
-            print("[AI 로거] GCP 연동 실패 - 콘솔로만 출력됩니다:", e)
-
-        # ✅ 콘솔 핸들러는 항상 추가
+        # 2. 콘솔 출력
         stream_handler = logging.StreamHandler()
         stream_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
         logger.addHandler(stream_handler)
+
+        # 3. Discord 핸들러 추가
+        discord_handler = DiscordHandler()
+        discord_handler.setFormatter(logging.Formatter("[AI] %(asctime)s %(levelname)s: %(message)s"))
+        logger.addHandler(discord_handler)
 
         logger.setLevel(logging.INFO)
         logger.propagate = False

--- a/src/core/cloud_logging.py
+++ b/src/core/cloud_logging.py
@@ -3,10 +3,10 @@ import sys
 import os
 import json
 from datetime import datetime, UTC
-from google.oauth2 import service_account
-from google.cloud import logging as gcp_logging
-from google.cloud.logging_v2.handlers import CloudLoggingHandler
-from src.config import CREDENTIAL_PATH
+# from google.oauth2 import service_account
+# from google.cloud import logging as gcp_logging
+# from google.cloud.logging_v2.handlers import CloudLoggingHandler
+# from src.config import CREDENTIAL_PATH
 
 # JSON 구조 콘솔 출력 포맷터
 class CloudLoggingFormatter(logging.Formatter):
@@ -23,38 +23,29 @@ class CloudLoggingFormatter(logging.Formatter):
             log_record["exception"] = self.formatException(record.exc_info)
         return json.dumps(log_record)
 
-# 로거 설정 함수
 def setup_logger() -> logging.Logger:
     logger = logging.getLogger("cloud")
+    logger.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
 
-    # .env에서 LOG_LEVEL 불러오기 (기본: INFO)
-    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-    logger.setLevel(log_level)
-
-    # 중복 핸들러 제거
     if logger.hasHandlers():
         logger.handlers.clear()
 
-    # 1. 콘솔 핸들러 (개발 시 디버깅용)
     stream_handler = logging.StreamHandler(sys.stdout)
-    stream_handler.setLevel(logging.DEBUG)
     stream_handler.setFormatter(CloudLoggingFormatter())
     logger.addHandler(stream_handler)
 
-    # 2. GCP Cloud Logging 핸들러 (운영용)
-    try:
-        credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_PATH)
-        client = gcp_logging.Client(credentials=credentials)
-        cloud_handler = CloudLoggingHandler(client)
-        cloud_handler.setLevel(logging.INFO)
-        logger.addHandler(cloud_handler)
-
-        logger.info("[로깅 초기화] GCP Cloud Logging 핸들러 적용 완료")
-
-    except Exception as e:
-        logger.warning(f"[로깅 초기화] GCP 핸들러 설정 실패: {e}")
+    # GCP Cloud Logging 보존
+    # try:
+    #     credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_PATH)
+    #     client = gcp_logging.Client(credentials=credentials)
+    #     cloud_handler = CloudLoggingHandler(client)
+    #     cloud_handler.setLevel(logging.INFO)
+    #     logger.addHandler(cloud_handler)
+    #     logger.info("[로깅 초기화] GCP Cloud Logging 핸들러 적용 완료")
+    # except Exception as e:
+    #     logger.warning(f"[로깅 초기화] GCP 핸들러 설정 실패: {e}")
 
     return logger
 
 # 외부에서 사용할 전역 로거 인스턴스
-logger = setup_logger()
+# logger = setup_logger()

--- a/src/core/exception_handler.py
+++ b/src/core/exception_handler.py
@@ -16,16 +16,16 @@ def setup_exception_handlers(app: FastAPI):
             503: "일시적으로 서비스를 사용할 수 없습니다.",
         }
 
+        # 422는 이미 유해성 차단 등으로 로깅되었으므로 여기선 생략
         if exc.status_code == 422:
             message = str(exc.detail)
         else:
             message = default_messages.get(exc.status_code, str(exc.detail))
-
-        ai_logger.warning("[AI] [예외 처리] HTTP 예외 발생", extra={
-            "status_code": exc.status_code,
-            "detail": str(exc.detail),
-            "path": request.url.path
-        })
+            ai_logger.warning("[AI] [예외 처리] HTTP 예외 발생", extra={
+                "status_code": exc.status_code,
+                "detail": str(exc.detail),
+                "path": request.url.path
+            })
 
         return JSONResponse(
             status_code=exc.status_code,

--- a/src/core/exception_handler.py
+++ b/src/core/exception_handler.py
@@ -2,11 +2,13 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
 
 def setup_exception_handlers(app: FastAPI):
     @app.exception_handler(StarletteHTTPException)
     async def http_exception_handler(request: Request, exc: StarletteHTTPException):
-        # 기본 메시지 설정
         default_messages = {
             400: "잘못된 요청입니다.",
             409: "이미 존재하는 리소스입니다.",
@@ -14,11 +16,16 @@ def setup_exception_handlers(app: FastAPI):
             503: "일시적으로 서비스를 사용할 수 없습니다.",
         }
 
-        # 422일 경우 exc.detail을 그대로 사용
         if exc.status_code == 422:
             message = str(exc.detail)
         else:
             message = default_messages.get(exc.status_code, str(exc.detail))
+
+        ai_logger.warning("[AI] [예외 처리] HTTP 예외 발생", extra={
+            "status_code": exc.status_code,
+            "detail": str(exc.detail),
+            "path": request.url.path
+        })
 
         return JSONResponse(
             status_code=exc.status_code,
@@ -30,7 +37,12 @@ def setup_exception_handlers(app: FastAPI):
         )
 
     @app.exception_handler(RequestValidationError)
-    async def validation_exception_handler(request, exc):
+    async def validation_exception_handler(request: Request, exc: RequestValidationError):
+        ai_logger.warning("[AI] [예외 처리] Request Validation 예외 발생", extra={
+            "errors": exc.errors(),
+            "path": request.url.path
+        })
+
         return JSONResponse(
             status_code=422,
             content={"code": 422, "message": "요청 형식이 잘못되었습니다. 필수 입력값을 확인해주세요.", "data": None},
@@ -38,6 +50,10 @@ def setup_exception_handlers(app: FastAPI):
 
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception):
+        ai_logger.exception("[AI] [예외 처리] 알 수 없는 서버 예외 발생", extra={
+            "path": request.url.path
+        })
+
         return JSONResponse(
             status_code=500,
             content={"code": 500, "message": "서버 내부 오류 발생", "data": None},

--- a/src/core/moderation.py
+++ b/src/core/moderation.py
@@ -2,11 +2,12 @@ import json
 import requests
 from datetime import datetime, UTC
 from src.config import PERSPECTIVE_API_KEY
-from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
 
 PERSPECTIVE_API_URL = f"https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key={PERSPECTIVE_API_KEY}"
 
-# 한국어에서 실제 지원되는 속성만 요청
 REQUESTED_ATTRIBUTES = {
     "TOXICITY": {},
     "INSULT": {},
@@ -14,8 +15,7 @@ REQUESTED_ATTRIBUTES = {
     "IDENTITY_ATTACK": {}
 }
 
-THRESHOLD = 0.45  # 유해하다고 판단하는 기준
-
+THRESHOLD = 0.45
 
 def get_harmfulness_scores_korean(text: str) -> dict:
     payload = {
@@ -24,55 +24,40 @@ def get_harmfulness_scores_korean(text: str) -> dict:
         "requestedAttributes": REQUESTED_ATTRIBUTES
     }
 
-    logger.info("[유해성 분석] Perspective API 요청 시작")
+    ai_logger.info("[AI] [Moderation 시작] Perspective API 요청", extra={"text_length": len(text)})
     start_time = datetime.now(UTC)
 
     response = requests.post(PERSPECTIVE_API_URL, json=payload)
 
     if response.status_code != 200:
-        logger.error(f"[유해성 분석][API 오류] 응답 코드: {response.status_code}", exc_info=True)
+        ai_logger.error("[AI] [Moderation 실패] 응답 코드 오류", extra={"status_code": response.status_code})
         raise Exception(f"Perspective API 오류: {response.status_code} - {response.text}")
 
     try:
-        result = {}
-        for attr in REQUESTED_ATTRIBUTES:
-            result[attr] = response.json()["attributeScores"][attr]["summaryScore"]["value"]
+        result = {
+            attr: response.json()["attributeScores"][attr]["summaryScore"]["value"]
+            for attr in REQUESTED_ATTRIBUTES
+        }
 
         latency_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
-        logger.info(f"[유해성 분석] 응답 파싱 성공 - 처리시간: {latency_ms}ms")
+        ai_logger.info("[AI] [Moderation 성공] 유해성 점수 파싱 완료", extra={"latency_ms": latency_ms, "scores": result})
         return result
 
     except KeyError:
-        logger.error("[유해성 분석][파싱 오류] 응답에서 키 누락", exc_info=True)
+        ai_logger.error("[AI] [Moderation 파싱 실패] 응답 키 누락", exc_info=True)
         raise
 
 def is_request_valid(scores: dict, threshold: float = THRESHOLD) -> bool:
     max_attr, max_score = max(scores.items(), key=lambda x: x[1])
-    logger.info(f"[유해성 분석] 최대 유해 점수: {max_attr}({max_score:.3f})")
+    ai_logger.info("[AI] [Moderation 평가] 최대 유해 점수", extra={"attribute": max_attr, "score": max_score})
     return max_score < threshold
 
-
-# 로그 저장용 함수
 def log_harmfulness_scores(scores: dict, text: str, log_path: str = "harmfulness_log.jsonl"):
     log_data = {
         "timestamp": datetime.utcnow().isoformat(),
         "text": text.strip(),
         "scores": scores
     }
-
-
-
-if __name__ == "__main__":
-    korean_text = """
-    이 모임은 멍청한 사람들 모아놓고 얼마나 비효율적인지 관찰하려고 만든 겁니다. 괜히 시간 낭비하지 마시고, 본인 해당되면 그냥 나오세요. 수준 낮은 애들끼리 노는 거예요.
-    """
-
-    logger.info("[테스트 실행] 유해성 분석 샘플 시작")
-    scores = get_harmfulness_scores_korean(korean_text)
-
-    logger.info("[테스트 실행] 유해성 점수 결과", extra={"scores": scores})
-
-    if not is_request_valid(scores):
-        logger.warning("[테스트 실행] 유해성 기준 초과로 요청 거부됨")
-    else:
-        logger.info("[테스트 실행] 요청 유효함")
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(log_data, ensure_ascii=False) + "\n")
+    ai_logger.info("[AI] [Moderation 저장] JSONL 로그 기록됨", extra={"log_path": log_path})

--- a/src/core/moderation.py
+++ b/src/core/moderation.py
@@ -2,7 +2,7 @@ import json
 import requests
 from datetime import datetime, UTC
 from src.config import PERSPECTIVE_API_KEY
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 PERSPECTIVE_API_URL = f"https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key={PERSPECTIVE_API_KEY}"
 

--- a/src/main.py
+++ b/src/main.py
@@ -38,9 +38,8 @@ if __name__ == "__main__":
     host = "0.0.0.0"
     port = 8000
     logger.info("[FastAPI 실행] 서버 시작 전 초기화")
-
     try:
-        uvicorn.run(app, host=host, port=port)
+        uvicorn.run(app, host=host, port=port, reload=True)
         logger.info("[FastAPI 실행 완료] 서버가 정상적으로 실행되었습니다.")
     except Exception as e:
         logger.error("[FastAPI 실행 오류] 서버 실행 중 예외 발생", exc_info=True)

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,7 @@
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from src.router.v1 import group_information
-from src.core.cloud_logging import logger  # 기존 시스템 전역 로거
-from src.core.ai_logger import get_ai_logger  # [AI] 전용 로거
+from src.core.ai_logger import get_ai_logger
 from src.core.exception_handler import setup_exception_handlers
 from src.middleware.ai_logger import AILoggingMiddleware
 import logging
@@ -10,7 +9,7 @@ import src.core.vertex_client
 
 # 로거 초기화
 ai_logger = get_ai_logger()
-logger.info("[시스템 시작] FastAPI 서버 초기화 및 Cloud Logging 활성화")
+ai_logger.info("[시스템 시작] FastAPI 서버 초기화 및 Cloud Logging 활성화")
 
 # 로깅 레벨 설정
 logging.getLogger("chromadb").setLevel(logging.WARNING)
@@ -24,7 +23,7 @@ app.add_middleware(AILoggingMiddleware)
 
 @app.get("/")
 def root():
-    logger.info("[루트 엔드포인트] / 호출됨")
+    ai_logger.info("[루트 엔드포인트] / 호출됨")
     return {"message": "Hello World: Version 1 API is running"}
 
 # [AI] 라우터 등록
@@ -37,9 +36,9 @@ if __name__ == "__main__":
     import uvicorn
     host = "0.0.0.0"
     port = 8000
-    logger.info("[FastAPI 실행] 서버 시작 전 초기화")
+    ai_logger.info("[FastAPI 실행] 서버 시작 전 초기화")
     try:
-        uvicorn.run(app, host=host, port=port, reload=True)
-        logger.info("[FastAPI 실행 완료] 서버가 정상적으로 실행되었습니다.")
+        uvicorn.run(app, host=host, port=port)
+        ai_logger.info("[FastAPI 실행 완료] 서버가 정상적으로 실행되었습니다.")
     except Exception as e:
-        logger.error("[FastAPI 실행 오류] 서버 실행 중 예외 발생", exc_info=True)
+        ai_logger.error("[FastAPI 실행 오류] 서버 실행 중 예외 발생", exc_info=True)

--- a/src/middleware/ai_logger.py
+++ b/src/middleware/ai_logger.py
@@ -1,25 +1,29 @@
+import time
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
-from time import time
 from src.core.ai_logger import get_ai_logger
 
 ai_logger = get_ai_logger()
 
 class AILoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        if request.url.path.startswith("/ai/v1/"):
-            start_time = time()
-            response: Response = await call_next(request)
-            process_time = time() - start_time
+        start_time = time.time()
+        response: Response = await call_next(request)
+        process_time = round(time.time() - start_time, 4)
 
-            ai_logger.info(f"{request.method} {request.url.path} - {response.status_code} - {process_time:.4f}s")
+        method = request.method
+        path = request.url.path
+        status_code = response.status_code
 
-            if 400 <= response.status_code < 500:
-                ai_logger.warning(f"[Client Error] {request.method} {request.url.path} - {response.status_code}")
-            elif response.status_code >= 500:
-                ai_logger.error(f"[Server Error] {request.method} {request.url.path} - {response.status_code}")
+        # 성공 로그
+        if status_code < 400:
+            ai_logger.info(f"[AI] {method} {path} - {status_code} - {process_time}s")
+        # 클라이언트 에러이지만 422는 제외 (중복 방지)
+        elif 400 <= status_code < 500 and status_code != 422:
+            ai_logger.warning(f"[Client Error] {method} {path} - {status_code}")
+        # 서버 에러
+        elif status_code >= 500:
+            ai_logger.error(f"[Server Error] {method} {path} - {status_code}")
 
-            return response
-        else:
-            return await call_next(request)
+        return response

--- a/src/middleware/ai_logger.py
+++ b/src/middleware/ai_logger.py
@@ -1,0 +1,25 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from time import time
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
+
+class AILoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path.startswith("/ai/v1/"):
+            start_time = time()
+            response: Response = await call_next(request)
+            process_time = time() - start_time
+
+            ai_logger.info(f"{request.method} {request.url.path} - {response.status_code} - {process_time:.4f}s")
+
+            if 400 <= response.status_code < 500:
+                ai_logger.warning(f"[Client Error] {request.method} {request.url.path} - {response.status_code}")
+            elif response.status_code >= 500:
+                ai_logger.error(f"[Server Error] {request.method} {request.url.path} - {response.status_code}")
+
+            return response
+        else:
+            return await call_next(request)

--- a/src/router/v1/group_information.py
+++ b/src/router/v1/group_information.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
 from src.schemas.v1.group_information import APIResponse, MeetingInput
 from src.services.v1.group_information import build_meeting_data
 from src.core.moderation import get_harmfulness_scores_korean, is_request_valid
-from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
+router = APIRouter()
 
 REJECTION_REASONS = {
     "TOXICITY": "전체적으로 공격적인 표현이 감지되었습니다.",
@@ -10,18 +14,17 @@ REJECTION_REASONS = {
     "THREAT": "위협적인 내용이 포함되어 있습니다.",
     "IDENTITY_ATTACK": "특정 집단이나 정체성을 공격하는 표현이 포함되어 있습니다."
 }
-router = APIRouter()
 
 @router.post("/groups/information", response_model=APIResponse)
-def create_meeting(meeting: MeetingInput):
-    logger.info("[POST /groups/information] 모임 정보 생성 요청 수신", extra={"meeting_name": meeting.name})
+def create_meeting(meeting: MeetingInput, request: Request):
+    ai_logger.info("[AI] [POST /groups/information] 모임 정보 생성 요청 수신", extra={"meeting_name": meeting.name})
     input_text = f"{meeting.name}\n{meeting.goal}"
 
     try:
         scores = get_harmfulness_scores_korean(input_text)
-        logger.info("[유해성 분석] 분석 결과 수신", extra={"scores": scores})
+        ai_logger.info("[AI] [유해성 분석] 분석 결과 수신", extra={"scores": scores})
     except Exception:
-        logger.exception("[유해성 분석] 분석 중 예외 발생")
+        ai_logger.exception("[AI] [유해성 분석] 분석 중 예외 발생")
         return JSONResponse(
             status_code=500,
             content={
@@ -31,18 +34,25 @@ def create_meeting(meeting: MeetingInput):
             }
         )
 
-
     if not is_request_valid(scores):
-        max_attr, _ = max(scores.items(), key=lambda x: x[1])
+        max_attr, max_score = max(scores.items(), key=lambda x: x[1])
         reason_msg = REJECTION_REASONS.get(max_attr, "부적절한 표현이 포함되어 있습니다.")
+
+        # ✅ 하나의 로그로 요약
+        ai_logger.warning("[AI] [유해성 차단] 요청 거부됨", extra={
+            "reason": reason_msg,
+            "attribute": max_attr,
+            "score": round(max_score, 3),
+            "endpoint": request.url.path
+        })
 
         raise HTTPException(status_code=422, detail=reason_msg)
 
     try:
         meeting_data = build_meeting_data(meeting)
-        logger.info("[모임 생성] 모임 정보 생성 성공")
+        ai_logger.info("[AI] [모임 생성] 모임 정보 생성 성공")
     except Exception:
-        logger.exception("[모임 생성] 모임 정보 생성 중 예외 발생")
+        ai_logger.exception("[AI] [모임 생성] 모임 정보 생성 중 예외 발생")
         return JSONResponse(
             status_code=500,
             content={

--- a/src/router/v1/group_information.py
+++ b/src/router/v1/group_information.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException
 from src.schemas.v1.group_information import APIResponse, MeetingInput
 from src.services.v1.group_information import build_meeting_data
 from src.core.moderation import get_harmfulness_scores_korean, is_request_valid
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 REJECTION_REASONS = {
     "TOXICITY": "전체적으로 공격적인 표현이 감지되었습니다.",

--- a/src/router/v1/group_writer.py
+++ b/src/router/v1/group_writer.py
@@ -1,31 +1,39 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from src.schemas.v1.group_writer import GroupGenerationRequest, GroupDescriptionResponse, GroupPlanResponse
 from src.services.v1.description_writer import generate_description
 from src.services.v1.plan_writer import generate_plan
-from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
 
+ai_logger = get_ai_logger()
 router = APIRouter()
 
-
 @router.post("/groups/description", response_model=GroupDescriptionResponse)
-def generate_group_description(data: GroupGenerationRequest) -> GroupDescriptionResponse:
+def generate_group_description(data: GroupGenerationRequest, request: Request) -> GroupDescriptionResponse:
+    ai_logger.info("[AI] [POST /groups/description] 그룹 소개 생성 요청 수신", extra={"meeting_name": data.name})
+
     try:
         summary, description = generate_description(data)
-        logger.info("[그룹 소개 생성] Gemini 요약 및 소개 생성 성공")
+        ai_logger.info("[AI] [그룹 소개 생성] Gemini 요약 및 소개 생성 성공")
         return GroupDescriptionResponse(summary=summary, description=description)
     except Exception:
-        logger.exception("[그룹 소개 생성] Gemini API 호출 또는 파싱 중 예외 발생")
+        ai_logger.exception("[AI] [그룹 소개 생성 실패] Gemini API 호출 또는 파싱 실패", extra={
+            "endpoint": request.url.path,
+            "meeting_name": data.name
+        })
         raise HTTPException(status_code=500, detail="그룹 소개 생성 중 오류가 발생했습니다.")
 
 
 @router.post("/groups/plan", response_model=GroupPlanResponse)
-def generate_group_plan(data: GroupGenerationRequest) -> GroupPlanResponse:
-    logger.info("[POST /groups/plan] 그룹 커리큘럼 생성 요청 수신", extra={"meeting_name": data.name})
+def generate_group_plan(data: GroupGenerationRequest, request: Request) -> GroupPlanResponse:
+    ai_logger.info("[AI] [POST /groups/plan] 그룹 커리큘럼 생성 요청 수신", extra={"meeting_name": data.name})
 
     try:
         plan = generate_plan(data)
-        logger.info("[그룹 커리큘럼 생성] 계획 생성 성공")
+        ai_logger.info("[AI] [그룹 커리큘럼 생성] 계획 생성 성공")
         return GroupPlanResponse(plan=plan)
     except Exception:
-        logger.exception("[그룹 커리큘럼 생성] Gemini API 호출 또는 파싱 중 예외 발생")
+        ai_logger.exception("[AI] [커리큘럼 생성 실패] Gemini API 호출 또는 파싱 실패", extra={
+            "endpoint": request.url.path,
+            "meeting_name": data.name
+        })
         raise HTTPException(status_code=500, detail="그룹 커리큘럼 생성 중 오류가 발생했습니다.")

--- a/src/router/v1/group_writer.py
+++ b/src/router/v1/group_writer.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException
 from src.schemas.v1.group_writer import GroupGenerationRequest, GroupDescriptionResponse, GroupPlanResponse
 from src.services.v1.description_writer import generate_description
 from src.services.v1.plan_writer import generate_plan
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 router = APIRouter()
 

--- a/src/router/v1/tag_extraction.py
+++ b/src/router/v1/tag_extraction.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from src.services.v1.tag_extraction import extract_tags
 from src.schemas.v1.tag_extraction import TagRequest, TagResponse
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 router = APIRouter()
 

--- a/src/router/v1/tag_extraction.py
+++ b/src/router/v1/tag_extraction.py
@@ -1,19 +1,22 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from src.services.v1.tag_extraction import extract_tags
 from src.schemas.v1.tag_extraction import TagRequest, TagResponse
-from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
 
+ai_logger = get_ai_logger()
 router = APIRouter()
 
 @router.post("/tag/extract", response_model=TagResponse)
-def extract_keyword(payload: TagRequest) -> TagResponse:
-  
-    logger.info("[POST /tag/extract] 키워드 추출 요청 수신", extra={"text_preview": payload.text[:30]})
+def extract_keyword(payload: TagRequest, request: Request):
+    ai_logger.info("[AI] [POST /tag/extract] 키워드 추출 요청 수신", extra={"text_preview": payload.text[:30]})
 
     try:
         tags = extract_tags(payload.text)
-        logger.info("[태그 추출] 태그 추출 성공", extra={"tag_count": len(tags)})
+        ai_logger.info("[AI] [태그 추출] 태그 추출 성공", extra={"tag_count": len(tags)})
         return TagResponse(tags=tags)
     except Exception:
-        logger.exception("[태그 추출] 태그 추출 중 오류 발생")
+        ai_logger.exception("[AI] [태그 추출 실패] 예외 발생", extra={
+            "endpoint": request.url.path,
+            "text_preview": payload.text[:30]
+        })
         raise HTTPException(status_code=500, detail="태그 추출 중 오류가 발생했습니다.")

--- a/src/services/v1/description_writer.py
+++ b/src/services/v1/description_writer.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 from src.schemas.v1.group_writer import GroupGenerationRequest
 from src.core.vertex_client import gen_model, config_model
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 
 def generate_description(data: GroupGenerationRequest) -> Tuple[str, str]:

--- a/src/services/v1/description_writer.py
+++ b/src/services/v1/description_writer.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 from src.schemas.v1.group_writer import GroupGenerationRequest
 from src.core.vertex_client import gen_model, config_model
-from src.core.cloud_logging import logger
+# from src.core.cloud_logging import logger
 from src.core.ai_logger import get_ai_logger
 
 ai_logger = get_ai_logger()

--- a/src/services/v1/embed.py
+++ b/src/services/v1/embed.py
@@ -1,5 +1,5 @@
 from src.core.vertex_client import embed_model
-from src.core.cloud_logging import logger
+# from src.core.cloud_logging import logger
 from src.core.ai_logger import get_ai_logger
 
 ai_logger = get_ai_logger()

--- a/src/services/v1/embed.py
+++ b/src/services/v1/embed.py
@@ -1,5 +1,5 @@
 from src.core.vertex_client import embed_model
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 def embed(texts: list[str] | str) -> list[list[float]]:
     if isinstance(texts, str):
@@ -26,13 +26,15 @@ if __name__ == "__main__":
 
     texts = [
         "나는 오늘 강남에서 커피를 마셨다.",
-        "서울 강남역 근처에는 카페가 정말 많다.",
+        "나는 나의 나비를 먹었나?",
         "나는 오늘 운동을 하지 못했다."
     ]
     try:
         vectors = embed(texts)
         print(f"임베딩 수: {len(vectors)}")
         print(f"벡터 길이: {len(vectors[0])}")
-        print(f"첫 벡터 앞 5개 값: {vectors[0][:5]}")
+
+        for text, vector in zip(texts, vectors):
+            print(f"{text}: {vector}")
     except Exception as e:
         print(f"오류 발생: {e}")

--- a/src/services/v1/embed.py
+++ b/src/services/v1/embed.py
@@ -1,5 +1,8 @@
 from src.core.vertex_client import embed_model
 from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
 
 def embed(texts: list[str] | str) -> list[list[float]]:
     if isinstance(texts, str):
@@ -8,33 +11,30 @@ def embed(texts: list[str] | str) -> list[list[float]]:
         raise ValueError("embed 함수는 문자열 또는 문자열 리스트만 지원합니다.")
 
     try:
-        logger.info("[임베딩 요청]", extra={"input_count": len(texts)})
+        ai_logger.info("[AI] [임베딩 요청]", extra={"input_count": len(texts)})
         embeddings = embed_model.get_embeddings(texts)
         vectors = [e.values for e in embeddings]
 
         if len(vectors) != len(texts):
-            logger.warning("[임베딩 수 불일치]", extra={"input_count": len(texts), "output_count": len(vectors)})
+            ai_logger.warning("[AI] [임베딩 수 불일치]", extra={"input_count": len(texts), "output_count": len(vectors)})
 
-        logger.info("[임베딩 완료]", extra={"vector_dim": len(vectors[0]) if vectors else 0})
+        ai_logger.info("[AI] [임베딩 완료]", extra={"vector_dim": len(vectors[0]) if vectors else 0})
         return vectors
 
     except Exception:
-        logger.exception("[임베딩 실패]")
+        ai_logger.exception("[AI] [임베딩 실패]")
         return []
 
 if __name__ == "__main__":
-
     texts = [
         "나는 오늘 강남에서 커피를 마셨다.",
-        "나는 나의 나비를 먹었나?",
+        "서울 강남역 근처에는 카페가 정말 많다.",
         "나는 오늘 운동을 하지 못했다."
     ]
     try:
         vectors = embed(texts)
         print(f"임베딩 수: {len(vectors)}")
         print(f"벡터 길이: {len(vectors[0])}")
-
-        for text, vector in zip(texts, vectors):
-            print(f"{text}: {vector}")
+        print(f"첫 벡터 앞 5개 값: {vectors[0][:5]}")
     except Exception as e:
         print(f"오류 발생: {e}")

--- a/src/services/v1/group_information.py
+++ b/src/services/v1/group_information.py
@@ -3,7 +3,7 @@ from src.schemas.v1.group_writer import GroupGenerationRequest
 from src.services.v1.tag_extraction import extract_tags
 from src.services.v1.description_writer import generate_description
 from src.services.v1.plan_writer import generate_plan
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 def build_meeting_data(input: MeetingInput) -> MeetingData:
     logger.info("[모임 정보 생성 시작]", extra={

--- a/src/services/v1/group_information.py
+++ b/src/services/v1/group_information.py
@@ -3,10 +3,12 @@ from src.schemas.v1.group_writer import GroupGenerationRequest
 from src.services.v1.tag_extraction import extract_tags
 from src.services.v1.description_writer import generate_description
 from src.services.v1.plan_writer import generate_plan
-from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
 
 def build_meeting_data(input: MeetingInput) -> MeetingData:
-    logger.info("[모임 정보 생성 시작]", extra={
+    ai_logger.info("[AI] [모임 정보 생성 시작]", extra={
         "meeting_name": input.name,
         "has_plan": input.isPlanCreated
     })
@@ -24,7 +26,7 @@ def build_meeting_data(input: MeetingInput) -> MeetingData:
         tags = extract_tags(description)
         plan = generate_plan(group_data) if input.isPlanCreated else None
 
-        logger.info("[모임 정보 생성 완료]")
+        ai_logger.info("[AI] [모임 정보 생성 완료]", extra={"tags_count": len(tags)})
 
         return MeetingData(
             name=input.name,
@@ -34,7 +36,7 @@ def build_meeting_data(input: MeetingInput) -> MeetingData:
             plan=plan,
         )
     except Exception:
-        logger.exception("[모임 정보 생성 실패]")
+        ai_logger.exception("[AI] [모임 정보 생성 실패]")
         return MeetingData(
             name=input.name,
             summary="",
@@ -43,10 +45,7 @@ def build_meeting_data(input: MeetingInput) -> MeetingData:
             plan=None,
         )
 
-
 if __name__ == "__main__":
-    from src.schemas.v1.group_information import MeetingInput
-
     test_input = MeetingInput(
         name="딥러닝 실전 스터디",
         goal="딥러닝 실전 프로젝트 완수와 포트폴리오 제작",
@@ -57,4 +56,3 @@ if __name__ == "__main__":
 
     result = build_meeting_data(test_input)
     print(result)
-

--- a/src/services/v1/plan_writer.py
+++ b/src/services/v1/plan_writer.py
@@ -1,6 +1,6 @@
 from src.schemas.v1.group_writer import GroupGenerationRequest
 from src.core.vertex_client import gen_model, config_model
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 def generate_plan(data: GroupGenerationRequest) -> str:
     prompt = f"""

--- a/src/services/v1/plan_writer.py
+++ b/src/services/v1/plan_writer.py
@@ -1,6 +1,6 @@
 from src.schemas.v1.group_writer import GroupGenerationRequest
 from src.core.vertex_client import gen_model, config_model
-from src.core.cloud_logging import logger
+# from src.core.cloud_logging import logger
 from src.core.ai_logger import get_ai_logger
 
 ai_logger = get_ai_logger()

--- a/src/services/v1/plan_writer.py
+++ b/src/services/v1/plan_writer.py
@@ -1,6 +1,9 @@
 from src.schemas.v1.group_writer import GroupGenerationRequest
 from src.core.vertex_client import gen_model, config_model
 from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
 
 def generate_plan(data: GroupGenerationRequest) -> str:
     prompt = f"""
@@ -36,24 +39,24 @@ def generate_plan(data: GroupGenerationRequest) -> str:
         - 기간: {data.period} (예: "1개월 이하", "1~3개월", "6개월~1년", "1년 이상")
         """
     try:
-        logger.info("[커리큘럼 생성 시작]", extra={"meeting_name": data.name})
+        ai_logger.info("[AI] [커리큘럼 생성 시작]", extra={"meeting_name": data.name})
         response = gen_model.generate_content(prompt, generation_config=config_model)
         result = response.text.strip()
 
         step_count = result.count("Step ")
-        logger.info("[커리큘럼 생성 완료]", extra={"steps": step_count, "text_length": len(result)})
+        ai_logger.info("[AI] [커리큘럼 생성 완료]", extra={"steps": step_count, "text_length": len(result)})
         return result
 
     except Exception as e:
-        logger.exception("[Vertex Gemini 단계별 계획 생성 실패]")
+        ai_logger.exception("[AI] [Vertex Gemini 단계별 계획 생성 실패]")
         return ""
 
 if __name__ == "__main__":
     from src.schemas.v1.group_writer import GroupGenerationRequest
 
     data = GroupGenerationRequest(
-        name=".",
-        goal=".",
+        name="토익 스터디 모임",
+        goal="함께 공부해서 다음 달 토익 시험 목표 점수 달성하기",
         category="학습/자기계발",
         period="2주",
         isPlanCreated=False

--- a/src/services/v1/tag_extraction.py
+++ b/src/services/v1/tag_extraction.py
@@ -43,7 +43,7 @@ def extract_tags(text: str) -> list[str]:
         try:
             tags = json.loads(raw)
         except json.JSONDecodeError:
-            ai_logger.warning("[AI] [JSON 파싱 실패] 테그 정규식으로 대체 처리", extra={"raw_preview": raw[:80]})
+            ai_logger.info("[AI] [JSON 파싱 실패] 테그 정규식으로 대체 처리", extra={"raw_preview": raw[:80]})
             tags = re.findall(r'"(.*?)"', raw)
 
         ai_logger.info("[AI] [태그 추출 완료]", extra={"tag_count": len(tags)})

--- a/src/services/v1/tag_extraction.py
+++ b/src/services/v1/tag_extraction.py
@@ -1,7 +1,7 @@
 import json
 import re
 from src.core.vertex_client import gen_model
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 def extract_tags(text: str) -> list[str]:
     prompt = f"""

--- a/src/services/v1/tag_extraction.py
+++ b/src/services/v1/tag_extraction.py
@@ -2,6 +2,9 @@ import json
 import re
 from src.core.vertex_client import gen_model
 from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
 
 def extract_tags(text: str) -> list[str]:
     prompt = f"""
@@ -33,21 +36,21 @@ def extract_tags(text: str) -> list[str]:
     raw = response.text.strip()
 
     try:
-        logger.info("[태그 추출 시작]", extra={"text_length": len(text)})
+        ai_logger.info("[AI] [태그 추출 시작]", extra={"text_length": len(text)})
         response = gen_model.generate_content(prompt)
         raw = response.text.strip()
 
         try:
             tags = json.loads(raw)
         except json.JSONDecodeError:
-            logger.warning("[JSON 파싱 실패] 정규식으로 대체 처리", extra={"raw_preview": raw[:80]})
+            ai_logger.warning("[AI] [JSON 파싱 실패] 테그 정규식으로 대체 처리", extra={"raw_preview": raw[:80]})
             tags = re.findall(r'"(.*?)"', raw)
 
-        logger.info("[태그 추출 완료]", extra={"tag_count": len(tags)})
+        ai_logger.info("[AI] [태그 추출 완료]", extra={"tag_count": len(tags)})
         return tags
 
     except Exception as e:
-        logger.exception("[Vertex Gemini 태그 추출 실패]")
+        ai_logger.exception("[AI] [Vertex Gemini 태그 추출 실패]")
         return []
 
 

--- a/src/services/v1/tag_extraction.py
+++ b/src/services/v1/tag_extraction.py
@@ -1,7 +1,7 @@
 import json
 import re
 from src.core.vertex_client import gen_model
-from src.core.cloud_logging import logger
+# from src.core.cloud_logging import logger
 from src.core.ai_logger import get_ai_logger
 
 ai_logger = get_ai_logger()

--- a/src/services/v1/vector_db.py
+++ b/src/services/v1/vector_db.py
@@ -5,7 +5,7 @@ from src.services.v1.embed import embed
 import numpy as np
 from typing import Callable
 import os
-from src.core.logging_config import logger
+from src.core.cloud_logging import logger
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 persist_dir = os.path.join(project_root, "data/chroma")

--- a/src/services/v1/vector_db.py
+++ b/src/services/v1/vector_db.py
@@ -1,11 +1,11 @@
 import chromadb
-# from chromadb.api.types import Documents, Embeddings
-# from chromadb.utils.embedding_functions import EmbeddingFunction
 from src.services.v1.embed import embed
 import numpy as np
 from typing import Callable
 import os
-from src.core.cloud_logging import logger
+from src.core.ai_logger import get_ai_logger
+
+ai_logger = get_ai_logger()
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
 persist_dir = os.path.join(project_root, "data/chroma")
@@ -15,29 +15,26 @@ collection = client.get_or_create_collection(name="nemo_vector_store")
 
 def add_to_chroma(doc_id: str, text: str):
     try:
-        logger.info(f"[벡터 추가] ID: {doc_id}")
+        ai_logger.info(f"[AI] [벡터 추가] ID: {doc_id}")
         vec = embed([text])
         if not vec or not vec[0]:
-            logger.error(f"[벡터 생성 실패] ID: {doc_id}")
+            ai_logger.error(f"[AI] [벡터 생성 실패] ID: {doc_id}")
             return
         collection.add(documents=[text], ids=[doc_id], embeddings=vec)
-        logger.info(f"[벡터 저장 완료] ID: {doc_id}")
-    except Exception as e:
-        logger.error(f"[ChromaDB 추가 실패] ID: {doc_id}")
-
+        ai_logger.info(f"[AI] [벡터 저장 완료] ID: {doc_id}")
+    except Exception:
+        ai_logger.exception(f"[AI] [ChromaDB 추가 실패] ID: {doc_id}")
 
 def search_chroma(query: str, k=3):
     try:
-        logger.info(f"[벡터 검색] 쿼리 길이: {len(query)}")
+        ai_logger.info(f"[AI] [벡터 검색] 쿼리 길이: {len(query)}")
         vec = embed([query])
         results = collection.query(query_embeddings=vec, n_results=k)
-        logger.info(f"[검색 결과] {len(results.get('ids', [[]])[0])}건 반환됨")
+        ai_logger.info(f"[AI] [검색 결과] {len(results.get('ids', [[]])[0])}건 반환됨")
         return results
-
-    except Exception as e:
-        logger.exception("[벡터 검색 실패]")
+    except Exception:
+        ai_logger.exception("[AI] [벡터 검색 실패]")
         return {}
-
 
 def pick_best_by_vector_similarity(
     candidates: list[list[str]],
@@ -45,7 +42,7 @@ def pick_best_by_vector_similarity(
     embed_fn: Callable[[list[str] | str], list[list[float]]]
 ) -> list[str]:
     try:
-        logger.info(f"[유사도 비교 시작] 후보 수: {len(candidates)}")
+        ai_logger.info(f"[AI] [유사도 비교 시작] 후보 수: {len(candidates)}")
         candidate_texts = [" ".join(tags) for tags in candidates]
         all_texts = [base_text] + candidate_texts
         embeddings = embed_fn(all_texts)
@@ -59,11 +56,10 @@ def pick_best_by_vector_similarity(
         ]
 
         best_idx = int(np.argmax(similarities))
-        logger.info(f"[유사도 최고] idx={best_idx}, 점수={similarities[best_idx]:.4f}")
+        ai_logger.info(f"[AI] [유사도 최고] idx={best_idx}, 점수={similarities[best_idx]:.4f}")
         return candidates[best_idx]
-
-    except Exception as e:
-        logger.exception("[유사도 계산 실패]")
+    except Exception:
+        ai_logger.exception("[AI] [유사도 계산 실패]")
         return []
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What  
> 무엇을 작업했는지 간결하게 적습니다.  

→ Cloud Logging 기반의 시스템 로깅을 완전히 제거하고, Discord 전용 로깅으로 마이그레이션했습니다.  
→ 유해성 필터링 시 중복으로 Discord에 전송되던 3개의 로그를 단일화하여,  
   이제는 `[AI] [유해성 차단] 요청 거부됨` 단 하나의 메시지만 전송됩니다.  
→ 모든 로깅 흐름은 `ai_logger` 단일 진입점으로 통합되었으며, 기존 `logger` 또는 `cloud_logging` 기반 코드들은 제거 또는 주석 처리했습니다.

---

## Why  
> 왜 이 작업을 했는지 설명합니다.  

→ Cloud Logging은 다음과 같은 이유로 제거하기로 결정하였습니다:  
   - 인증 방식 및 자격 증명 설정이 복잡하고,  
   - GCP 리소스를 사용하는 만큼 비용이 추가되며,  
   - Discord와 콘솔에서 동일한 로그가 이중으로 기록되어 관리가 번거로웠습니다.  
→ 실제 운영 관점에서는 Discord 로그만으로 실시간 모니터링과 알림이 충분하다고 판단하였습니다.  
→ 특히 유해성 필터링(422 오류 등) 시 하나의 사용자 요청으로 Discord에 동일 의미의 로그가 **최대 3번** 전송되며  
   알림 피로(alert fatigue)를 유발하는 문제가 있어, 이를 구조적으로 해결했습니다.

---

## Changes  
> 주요 변경사항을 적습니다.  

→ `src/core/ai_logger.py`:  
   - `google.cloud.logging` 및 `CloudLoggingHandler` 관련 코드 전부 주석 처리  
   - 콘솔 + Discord 로거만 남기고 통합 구성  
→ `src/core/logging_config.py`:  
   - JSON 포맷 콘솔 로깅은 유지, GCP 연동 코드 제거  
→ `main.py` 및 전체 서비스 코드:  
   - `cloud_logging.logger` 사용 전면 제거  
   - `get_ai_logger()` 기반 `ai_logger`로 통일  
→ `AILoggingMiddleware`:  
   - `422` 상태코드에 대해서는 Discord 전송 생략 (중복 방지 목적)  
→ `setup_exception_handlers()`:  
   - `StarletteHTTPException` 처리 시 `422` 상태는 로깅 생략  
→ `group_information.py`:  
   - `[AI] [유해성 차단] 요청 거부됨` 로그 **하나만 Discord로 전송**되도록 위치 고정  
→ `tag_extraction.py`, `group_writer.py`:  
   - 예외 발생 시 단일 로그 메시지로 정리 (추가 로깅 방지)

---

## Related Issue  
> 관련 이슈 번호를 연결합니다.  

→ #31
