### PR TITLE
infra: add CI/CD workflows for prod server

### DIFF
--- a/.github/workflows/cicd-v1-dev.yaml
+++ b/.github/workflows/cicd-v1-dev.yaml
@@ -2,7 +2,7 @@ name: AI CI/CD for dev-v1
 
 on:
   push:
-    branches: [develop, infra/ci-cd]
+    branches: [ develop ]
 
 jobs:
   deploy:

--- a/.github/workflows/cicd-v1-prod.yaml
+++ b/.github/workflows/cicd-v1-prod.yaml
@@ -1,0 +1,26 @@
+name: AI CI/CD for prod-v1
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to AI Prod Server via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            cd ~/nemo/ai/scripts
+            bash deploy.sh


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

운영(prod) 환경 전용 AI CI/CD 워크플로우를 추가하였습니다.
- `cicd-v1-prod.yaml`  
  - main 브랜치 푸시 → GitHub Actions → workflow_dispatch → 수동 승인 후 `deploy.sh` 실행

## Why
> 왜 이 작업을 했는지 설명합니다.

- 운영 배포는 수동 승인 기반 플로우로 구분되어야 하며, main 브랜치 기준으로 구성되어야 함  
- 실수로 운영 배포가 자동 실행되는 것을 방지하기 위함

## Changes
> 주요 변경사항을 적습니다.

- `.github/workflows/cicd-v1-prod.yaml` 추가

## Notes
> 참고 내용을 적습니다.

- 다음 시크릿이 GitHub에 등록되어 있어야 함
  - `PROD_SSH_KEY`  
  - `PROD_USER`  
  - `PROD_HOST`  
- 운영 서버 내 경로:
  - `~/nemo/ai/scripts/deploy.sh` 존재 필요

- `environment: prod`을 설정하였으며, GitHub Environments 메뉴에서 승인자 설정 가능

## Related Issue